### PR TITLE
feat(sns): add displayName property to a Topic

### DIFF
--- a/packages/aws-cdk-lib/aws-sns/README.md
+++ b/packages/aws-cdk-lib/aws-sns/README.md
@@ -331,3 +331,14 @@ const topic = new sns.Topic(this, 'MyTopic', {
   tracingConfig: sns.TracingConfig.ACTIVE,
 });
 ```
+
+## Display Name
+
+You can set a display name for the topic.
+To set a display name, use the `displayName` property:
+
+```ts
+const topic = new sns.Topic(this, 'Topic', {
+  displayName: 'MyDisplayName',
+});
+\```

--- a/packages/aws-cdk-lib/aws-sns/lib/topic.ts
+++ b/packages/aws-cdk-lib/aws-sns/lib/topic.ts
@@ -88,6 +88,15 @@ export interface TopicProps {
    * @default TracingConfig.PASS_THROUGH
    */
   readonly tracingConfig?: TracingConfig;
+
+  /**
+   * The display name to use for an Amazon SNS topic with SMS subscriptions.
+   *
+   * The display name must be maximum 100 characters long, including hyphens (-), underscores (_), spaces, and tabs.
+   *
+   * @default - no display name
+   */
+    readonly displayName?: string;
 }
 
 /**
@@ -300,6 +309,7 @@ export class Topic extends TopicBase {
       signatureVersion: props.signatureVersion,
       deliveryStatusLogging: Lazy.any({ produce: () => this.renderLoggingConfigs() }, { omitEmptyArray: true }),
       tracingConfig: props.tracingConfig,
+      displayName: props.displayName,
     });
 
     this.topicArn = this.getResourceArnAttribute(resource.ref, {

--- a/packages/aws-cdk-lib/aws-sns/test/sns.test.ts
+++ b/packages/aws-cdk-lib/aws-sns/test/sns.test.ts
@@ -9,6 +9,18 @@ import * as sns from '../lib';
 
 describe('Topic', () => {
   describe('topic tests', () => {
+    test('specify displayName', () => {
+      const stack = new cdk.Stack();
+    
+      new sns.Topic(stack, 'MyTopic', {
+         displayName: 'MyDisplayName',
+      });
+    
+      Template.fromStack(stack).hasResourceProperties('AWS::SNS::Topic', {
+        DisplayName: 'MyDisplayName',
+      });
+    });
+
     test('all defaults', () => {
       const stack = new cdk.Stack();
       new sns.Topic(stack, 'MyTopic');


### PR DESCRIPTION
### Issue # (if applicable)

Closes #1

### Reason for this change

We can set a display name for an SNS topic from cloudformation, but this was not supported in the AWS CDK L2 construct.

### Description of changes

Add displayName property to TopicProps and set it in the CfnTopic constructor.

### Description of how you validated changes

Added both unit and integration tests.

### Checklist
- [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
