### PR TITLE
feat(sns): add displayName property to a Topic

### DIFF
--- a/packages/@aws-cdk-testing/framework-integ/test/aws-sns/test/integ.sns-display-name.ts
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-sns/test/integ.sns-display-name.ts
@@ -1,0 +1,26 @@
+// packages/@aws-cdk-testing/framework-integ/test/aws-sns/test/integ.sns-display-name.ts
+import { App, Stack, StackProps } from 'aws-cdk-lib';
+import { Topic } from 'aws-cdk-lib/aws-sns';
+import * as integ from '@aws-cdk/integ-tests-alpha';
+
+// テスト用のStackを定義
+class TestStack extends Stack {
+  constructor(scope: App, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    new Topic(this, 'MyTopic', {
+      topicName: 'MyTopicName',
+      // displayNameを設定
+      displayName: 'MyDisplayName',
+    });
+  }
+}
+
+const app = new App();
+
+const stack = new TestStack(app, 'DisplayNameTopicTestStack');
+
+// 統合テストの実行
+new integ.IntegTest(app, 'SnsTest', {
+  testCases: [stack],
+});

--- a/packages/aws-cdk-lib/aws-sns/README.md
+++ b/packages/aws-cdk-lib/aws-sns/README.md
@@ -331,3 +331,14 @@ const topic = new sns.Topic(this, 'MyTopic', {
   tracingConfig: sns.TracingConfig.ACTIVE,
 });
 ```
+
+## Display Name
+
+You can set a display name for the topic.
+To set a display name, use the `displayName` property:
+
+```ts
+const topic = new sns.Topic(this, 'Topic', {
+  displayName: 'MyDisplayName',
+});
+```

--- a/packages/aws-cdk-lib/aws-sns/lib/topic.ts
+++ b/packages/aws-cdk-lib/aws-sns/lib/topic.ts
@@ -88,6 +88,17 @@ export interface TopicProps {
    * @default TracingConfig.PASS_THROUGH
    */
   readonly tracingConfig?: TracingConfig;
+
+  /**
+   * The display name to use for an Amazon SNS topic with SMS subscriptions.
+   *
+   * The display name must be maximum 100 characters long, including hyphens (-), underscores (_), spaces, and tabs.
+   *
+   * @see https://docs.aws.amazon.com/sns/latest/dg/sns-create-topic.html
+   * 
+   * @default - no display name
+   */
+  readonly displayName?: string;
 }
 
 /**
@@ -300,6 +311,7 @@ export class Topic extends TopicBase {
       signatureVersion: props.signatureVersion,
       deliveryStatusLogging: Lazy.any({ produce: () => this.renderLoggingConfigs() }, { omitEmptyArray: true }),
       tracingConfig: props.tracingConfig,
+      displayName: props.displayName,
     });
 
     this.topicArn = this.getResourceArnAttribute(resource.ref, {

--- a/packages/aws-cdk-lib/aws-sns/test/sns.test.ts
+++ b/packages/aws-cdk-lib/aws-sns/test/sns.test.ts
@@ -148,6 +148,18 @@ describe('Topic', () => {
         signatureVersion: '3',
       })).toThrow(/signatureVersion must be "1" or "2", received: "3"/);
     });
+
+    test('specify displayName', () => {
+      const stack = new cdk.Stack();
+    
+      new sns.Topic(stack, 'MyTopic', {
+         displayName: 'MyDisplayName',
+      });
+    
+      Template.fromStack(stack).hasResourceProperties('AWS::SNS::Topic', {
+        DisplayName: 'MyDisplayName',
+      });
+    });
   });
 
   test('can add a policy to the topic', () => {


### PR DESCRIPTION
### Issue #1  (if applicable)

Closes #1 

### Reason for this change

We can set a display name for an SNS topic from cloudformation, but this was not supported in the AWS CDK L2 construct.


<!--What is the bug or use case behind this change?-->

### Description of changes

Add displayName property to TopicProps and set it in the CfnTopic constructor.


<!--What code changes did you make? Have you made any important design decisions?-->

### Description of how you validated changes

Added both unit and integration tests.
--


<br class="Apple-interchange-newline">

<!--Have you added any unit tests and/or integration tests?-->

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
